### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,9 @@ jobs:
     name: Benchmark
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/22](https://github.com/murugan-kannan/ferragate/security/code-scanning/22)

To fix the issue, we need to add a `permissions` block to the `Benchmark` job to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the job uploads artifacts and comments on pull requests, it requires `contents: read` and `issues: write` permissions. These permissions are sufficient for the job's functionality while adhering to the principle of least privilege.

The changes will be made in the `.github/workflows/ci.yml` file, specifically within the `Benchmark` job definition. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
