### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,6 +225,9 @@ jobs:
     name: Deploy Documentation
     needs: create-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/21](https://github.com/murugan-kannan/ferragate/security/code-scanning/21)

To fix the issue, add a `permissions` block to the `Deploy Documentation` job. This block should specify the minimal permissions required for the job to function. Based on the job's steps, it only needs `contents: read` to check out the repository and `pages: write` to deploy documentation to GitHub Pages. Adding this block ensures that the job has only the necessary permissions and avoids unintended access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
