### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/1](https://github.com/murugan-kannan/ferragate/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, it primarily involves checking out code, running tests, and performing static analysis. These tasks typically require only `contents: read` permission. If any job requires additional permissions (e.g., `pull-requests: write`), they can be specified at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
