### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ env:
 jobs:
   create-release:
     name: Create Release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/2](https://github.com/murugan-kannan/ferragate/security/code-scanning/2)

To fix the problem, add a `permissions` block to the `create-release` job in `.github/workflows/release.yml`. The minimal required permission for creating a release is `contents: write`. This should be set directly under the job definition (`create-release:`), above the `runs-on` key. No other changes are needed, and existing functionality will be preserved. No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
