### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,6 @@
 name: Nightly
+permissions:
+  contents: read
 
 on:
   schedule:
@@ -38,6 +40,9 @@ jobs:
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -77,6 +82,8 @@ jobs:
   performance-baseline:
     name: Performance Baseline
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/3](https://github.com/murugan-kannan/ferragate/security/code-scanning/3)

To fix the problem, add an explicit `permissions` block at the top level of the workflow file, setting the default to the least privilege required (usually `contents: read`). For jobs that require additional permissions (such as uploading SARIF results to the GitHub Security tab or pushing benchmark results), add a `permissions` block at the job level with the necessary write permissions (e.g., `security-events: write` for SARIF upload, `contents: write` for pushing benchmark results). This ensures that each job only has the permissions it needs, and the default is as restrictive as possible.

**Steps:**
- Add `permissions: contents: read` after the `name` and before `on` at the top of the file.
- For the `security-scan` job, add `permissions: security-events: write, contents: read` (for uploading SARIF).
- For the `performance-baseline` job, add `permissions: contents: write` (for pushing benchmark results).
- Other jobs can inherit the default `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
