### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy
 
+permissions:
+  contents: read
+
 on:
   workflow_run:
     workflows: ["Release"]


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/4](https://github.com/murugan-kannan/ferragate/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the root of the workflow. This block will define the minimum required permissions for the workflow. Based on the tasks performed in the workflow (e.g., checking out code, configuring AWS credentials, deploying to Kubernetes), the workflow likely requires `contents: read` and possibly other specific permissions. For now, we will start with `contents: read` as a minimal baseline and adjust if additional permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
