### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,9 @@ jobs:
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/5](https://github.com/murugan-kannan/ferragate/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the `Security Scan` job to explicitly define the minimal permissions required. Based on the job's functionality, it only needs to read repository contents and upload SARIF files to the GitHub Security tab. Therefore, we will set `contents: read` and `security-events: write` permissions for this job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
