### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,8 @@ jobs:
 
   build-and-upload:
     name: Build and Upload (${{ matrix.target }})
+    permissions:
+      contents: write
     needs: create-release
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/7](https://github.com/murugan-kannan/ferragate/security/code-scanning/7)

To fix the problem, add a `permissions` block to the `build-and-upload` job in `.github/workflows/release.yml`. This block should grant only the permissions required for the job to function. Since the job uploads release assets, it needs `contents: write`. Other permissions can be omitted or set to their minimal values. The change should be made by adding the following under the `build-and-upload:` job definition (before `runs-on:`):

```yaml
permissions:
  contents: write
```

No additional imports or definitions are needed; this is a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
