### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,6 +58,8 @@ jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/8](https://github.com/murugan-kannan/ferragate/security/code-scanning/8)

To fix the issue, we will add an explicit `permissions` block to the `dependency-review` job. Since this job only checks for outdated dependencies and performs a security audit, it does not require write permissions. We will set the permissions to `contents: read`, which is the minimal required permission for this job. This change will ensure that the `GITHUB_TOKEN` has the least privilege necessary to complete the task.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
