### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,6 +77,8 @@ jobs:
   performance-baseline:
     name: Performance Baseline
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/9](https://github.com/murugan-kannan/ferragate/security/code-scanning/9)

To fix the problem, we should add a `permissions` block to the "Performance Baseline" job in `.github/workflows/nightly.yml`. This block should grant only the permissions required for the job to function. For the "Performance Baseline" job, the only step that requires write access is the benchmark upload step (`auto-push: true`), which needs `contents: write`. All other steps only require read access. Therefore, we should set `contents: write` for this job. The change should be made by adding a `permissions` block under the `performance-baseline` job definition, before the `steps` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
