### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,6 +93,8 @@ jobs:
     name: Deploy to Production
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production'
+    permissions:
+      contents: read
     environment:
       name: production
       url: https://ferragate.example.com


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/10](https://github.com/murugan-kannan/ferragate/security/code-scanning/10)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimal permissions required for the `deploy-production` job. Based on the job's steps, it primarily interacts with the repository's contents and uses secrets for deployment. Therefore, we will set `contents: read` to allow read-only access to the repository's contents and ensure no unnecessary write permissions are granted.

The `permissions` block will be added under the `deploy-production` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
