### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/11](https://github.com/murugan-kannan/ferragate/security/code-scanning/11)

To fix the problem, we should add a `permissions` block to the workflow or to each job, specifying the minimal permissions required. Since none of the jobs in the provided workflow need to write to the repository or interact with issues or pull requests, the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (for more granular control). The simplest and most maintainable fix is to add the following block near the top of the workflow, after the `name` and before `on`:

```yaml
permissions:
  contents: read
```

This ensures that all jobs in the workflow only have read access to repository contents via the `GITHUB_TOKEN`, reducing the risk of privilege escalation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
