### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/13](https://github.com/murugan-kannan/ferragate/security/code-scanning/13)

To fix the problem, explicitly set the `permissions` key at the top level of the workflow file. This will apply the specified permissions to all jobs in the workflow unless a job overrides them. Since none of the jobs in the provided snippet appear to require write access to the repository, the minimal required permission is `contents: read`. This adheres to the principle of least privilege and satisfies the CodeQL recommendation. The change should be made near the top of the file, after the `name` and before or after the `on` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
