### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy
 
+permissions:
+  contents: read
+
 on:
   workflow_run:
     workflows: ["Release"]


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/14](https://github.com/murugan-kannan/ferragate/security/code-scanning/14)

To fix the problem, add a `permissions` block to the workflow file. The best practice is to set this at the top level of the workflow, so it applies to all jobs unless overridden. The minimal permissions required for this workflow are likely `contents: read`, since the jobs only check out code and interact with external services (AWS, Slack) but do not write to the repository or modify issues/pull requests. If any job or step requires more permissions, you can override the `permissions` block at the job level. The change should be made at the top of `.github/workflows/deploy.yml`, after the `name:` and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
