### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,8 @@ jobs:
   cargo-deny:
     name: Cargo Deny
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/15](https://github.com/murugan-kannan/ferragate/security/code-scanning/15)

To fix the issue, we need to add a `permissions` block to the `Cargo Deny` job in the workflow file. The permissions should be limited to the least privilege required for the job to function correctly. Since the job involves auditing and checking dependencies, it only requires read access to the repository contents. 

The `permissions` block should be added directly under the `Cargo Deny` job definition, specifying `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
