### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]
@@ -146,6 +149,8 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/16](https://github.com/murugan-kannan/ferragate/security/code-scanning/16)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, the `contents: read` permission is sufficient for most jobs, as they primarily involve checking out the repository and running commands. For the `coverage` job, which uploads reports to Codecov, we will also include `contents: write` to allow artifact uploads.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
