### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,8 @@ jobs:
     name: Build and Push Docker Images
     needs: create-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/17](https://github.com/murugan-kannan/ferragate/security/code-scanning/17)

To fix the problem, add a `permissions` block to the `docker-release` job in `.github/workflows/release.yml`. The minimal required permission for this job is `contents: read`, which allows the job to read repository contents but not write to them. This change should be made directly under the `docker-release:` job definition (i.e., at the same indentation level as `name`, `needs`, and `runs-on`). No other changes are required, and this will not affect the existing functionality of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
