### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/18](https://github.com/murugan-kannan/ferragate/security/code-scanning/18)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/ci.yml`. This block can be added at the top level (applies to all jobs) or to individual jobs. Since most jobs in this workflow only need to read repository contents (e.g., for checking out code, building, testing, and documentation), the minimal required permission is `contents: read`. If any job requires additional permissions (such as uploading artifacts or interacting with pull requests), those can be added as needed. For now, the best fix is to add the following block near the top of the workflow file, after the `name` and before `on`:

```yaml
permissions:
  contents: read
```

This ensures that all jobs in the workflow run with the least privilege necessary, unless overridden at the job level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
