### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,8 @@ jobs:
     name: Publish to Crates.io
     needs: [create-release, build-and-upload]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/19](https://github.com/murugan-kannan/ferragate/security/code-scanning/19)

To fix the issue, add a `permissions` block to the `publish-crate` job. This block should explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum required. Since the job does not appear to require write access to repository contents or other elevated permissions, the `contents: read` permission is sufficient.

The `permissions` block should be added directly under the `runs-on` key in the `publish-crate` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
