### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,8 @@ jobs:
     name: Publish to Crates.io
     needs: [create-release, build-and-upload]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/19](https://github.com/murugan-kannan/ferragate/security/code-scanning/19)

To fix the issue, we will add a `permissions` block to the `publish-crate` job. Since the job only needs to authenticate with the `GITHUB_TOKEN` for publishing to crates.io, the minimal required permission is `contents: read`. This ensures that the job has the least privilege necessary to perform its tasks.

The `permissions` block will be added directly under the `publish-crate` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
