### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,9 @@ jobs:
     name: Build and Push Docker Images
     needs: create-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/17](https://github.com/murugan-kannan/ferragate/security/code-scanning/17)

To fix the issue, we will add a `permissions` block to the `docker-release` job. This block will explicitly define the minimal permissions required for the job to function correctly. Based on the job's steps, it primarily interacts with the GitHub Container Registry and Docker Hub, so it likely only needs `contents: read` and possibly `packages: write` permissions. These permissions will be explicitly set in the `docker-release` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
