### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,8 @@ jobs:
   nightly-test:
     name: Nightly Rust Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     continue-on-error: true
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Potential fix for [https://github.com/murugan-kannan/ferragate/security/code-scanning/3](https://github.com/murugan-kannan/ferragate/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `nightly-test` job. Since the job only needs to read the repository contents to run tests, we will set `contents: read` as the permission. This ensures that the job has the minimal permissions required to function correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
